### PR TITLE
Delete bigmat and debug output routines

### DIFF
--- a/src/casci_ty.f90
+++ b/src/casci_ty.f90
@@ -22,16 +22,6 @@ SUBROUTINE casci_ty(totsym)
     real(8) :: expected_mem
     integer :: datetmp0, datetmp1
     real(8) :: tsectmp0, tsectmp1
-#ifdef CASMAT_DEBUG
-    character(50)           :: chr_rank, matfilename
-    integer, parameter      :: mat_unit_num = 1000
-    real*8             :: matvalr, matvali
-    complex(16), allocatable :: mat_not_zero(:)
-    integer, allocatable    :: mat_i_order(:), mat_j_order(:)
-    integer                 :: not_zero_sum, not_zero_count, loop_idx, read_count, loop_sum, not_zero_count_modified
-    integer :: idx1, idx2, matcount, matdiagcount
-    real(8) :: not_zero_percentage
-#endif
 
     ndet = comb(nact, nelec)
     if (rank == 0) then ! Process limits for output
@@ -46,118 +36,16 @@ SUBROUTINE casci_ty(totsym)
         write (*, *) 'expected used memory after allocate mat is ', expected_mem/1024/1024, 'MB'
     end if
 
-#ifdef CASMAT_DEBUG
-    not_zero_count = 0
-    call casmat_modified(not_zero_count)
-    if (rank == 0) write (*, *) 'Noda end casmat_modified'
-    not_zero_sum = not_zero_count
-    call MPI_Allreduce(MPI_IN_PLACE, not_zero_sum, 1, MPI_INTEGER8, MPI_SUM, MPI_COMM_WORLD, ierr)
-
-    if (rank == 0) then
-        not_zero_percentage = (real(not_zero_sum, 8)/real((ndet**2), 8))*100
-        write (*, *) 'Noda end casmat_modified, not_zero_sum:', not_zero_sum, &
-            ' all', ndet**2, ' percentage', not_zero_percentage, '%'
-    end if
-    if (rank == 0) then
-        allocate (mat_not_zero(not_zero_sum))
-        allocate (mat_i_order(not_zero_sum))
-        allocate (mat_j_order(not_zero_sum))
-        if (rank == 0) write (*, *) "Noda nprocs check", nprocs
-        read_count = 0
-        not_zero_count_modified = 0
-        do loop_idx = 0, nprocs - 1
-            write (chr_rank, *) loop_idx
-            matfilename = 'mat'//trim(adjustl(chr_rank))
-            if (rank == 0) write (*, *) "Noda matfilename check", trim(matfilename)
-            open (mat_unit_num, file=matfilename, form='unformatted')
-103         read (mat_unit_num, err=101, end=102) i, j, matvalr, matvali
-            if (i == j) then
-                read_count = read_count + 1
-                not_zero_count_modified = not_zero_count_modified + 1
-            else
-                read_count = read_count + 1
-                not_zero_count_modified = not_zero_count_modified + 2
-            end if
-            mat_i_order(read_count) = i
-            mat_j_order(read_count) = j
-            mat_not_zero(read_count) = matvalr
-
-            goto 103
-101         write (*, *) 'mat_read_error', rank, nprocs
-102         if (rank == 0) then
-                not_zero_percentage = (real(not_zero_count_modified, 8)/real((ndet**2), 8))*100
-                write (*, *) 'Noda end read casmat_modified, not_zero_count_modified:', not_zero_count_modified, &
-                    ' all', ndet**2, ' percentage', not_zero_percentage, '%'
-            end if
-            close (mat_unit_num)
-        end do
-    end if
-    loop_sum = read_count
-    ! if (rank == 0) then
-    !     write (*, *) 'mat mat_not_zero diff check'
-    !     do loop_idx = 1, not_zero_sum
-    !         if (mat(mat_i_order(loop_idx), mat_j_order(loop_idx)) /= mat_not_zero(loop_idx)) then
-    !             write (*, '(A,I5,A,I5,A,E20.10)') 'Noda mat/=mat_not_zero i: ', mat_i_order(loop_idx), &
-    !                 ' j: ', mat_j_order(loop_idx), 'mat ', mat(mat_i_order(loop_idx), mat_j_order(loop_idx)), mat_not_zero(loop_idx)
-    !         end if
-    !         write (*, '(A,I5,A,I5,A,2E20.10)') 'Noda modified mat i: ', mat_i_order(loop_idx), ' j: ',&
-    !                 mat_j_order(loop_idx), ' mat:', mat_not_zero(loop_idx)
-    !     end do
-    !     write (*, *) 'end mat mat_not_zero diff check'
-    ! end if
-#endif
 #ifdef HAVE_MPI
     call MPI_Barrier(MPI_COMM_WORLD, ierr)
 #endif
-#ifdef BIG_MAT
-    if (rank == 0) then
-        Allocate (mat(ndet, ndet)); Call memplus(KIND(mat), SIZE(mat), 2)
-        write (*, *) "end allocate mat(ndet,ndet)"
-        write (*, '("Current Memory is ",F10.2,"MB")') tmem/1024/1024
-        Call casmat(mat)
-    end if
-#else
     Allocate (mat(ndet, ndet)); Call memplus(KIND(mat), SIZE(mat), 2)
     if (rank == 0) then
         write (*, *) "end allocate mat(ndet,ndet)"
         write (*, '("Current Memory is ",F10.2,"MB")') tmem/1024/1024
     end if
     Call casmat(mat)
-#endif
-#ifdef CASMAT_DEBUG
-    if (rank == 0) then
-        matcount = 0
-        matdiagcount = 0
-        write (*, *) 'Noda end casmat'
-        do idx1 = 1, ndet
-            do idx2 = idx1, ndet
-                if (mat(idx2, idx1) /= 0.0d+00) then
-                    if (idx1 == idx2) then
-                        matdiagcount = matdiagcount + 1
-                        matcount = matcount + 1
-                    else
-                        matcount = matcount + 2
-                    end if
-                    ! write (*, *) idx2, idx1, mat(idx2, idx1), mat(idx1, idx2)
-                end if
-            end do
-        end do
-        not_zero_percentage = (real(matcount, 8)/real((ndet**2), 8))*100
-        write (*, *) 'matcount', matcount, ' all', ndet**2, ' percentage', not_zero_percentage, '%'
-        write (*, *) 'matdiagcount', matdiagcount, ' ndet', ndet
-    end if
-    if (rank == 0) write (*, *) 'mat,mat_not_zero diff check'
-    do read_count = 1, loop_sum
-!   if (rank == 0.and.abs(real(mat(mat_i_order(read_count), mat_j_order(read_count)),8)-real(mat_not_zero(read_count),8))>1.0d-15)then
-       if (rank == 0 .and. real(mat(mat_i_order(read_count), mat_j_order(read_count)), 8) /= real(mat_not_zero(read_count), 8)) then
-            write (*, '(A,I5,A,I5,A,2E20.10,A,E20.10)') 'Noda check i: ', mat_i_order(read_count), &
-                ' j: ', mat_j_order(read_count), &
-                'mat ', real(mat(mat_i_order(read_count), mat_j_order(read_count)), 8), real(mat_not_zero(read_count), 8), &
-                'diff ', (real(mat(mat_i_order(read_count), mat_j_order(read_count)), 8) - real(mat_not_zero(read_count), 8))
-        end if
-    end do
-    if (rank == 0) write (*, *) 'mat,mat_not_zero diff check end'
-#endif
+
     if (rank == 0) then ! Process limits for output
         write (*, *) 'before allocate ecas(ndet)'
     end if
@@ -175,27 +63,8 @@ SUBROUTINE casci_ty(totsym)
     tsectmp1 = tsectmp0
 
     if (rank == 0) write (*, *) 'Noda ndet before cdiag', ndet
-#ifdef BIG_MAT
-    if (rank == 0) then
-        ! Only the master process has a matrix named mat.
-        ! So only the master process will diagonalize this matrix.
-        Call cdiag(mat, ndet, ndet, ecas, thresd, cutoff)
-    end if
-#else
     Call cdiag(mat, ndet, ndet, ecas, thresd, cutoff)
-#endif
-#ifdef CASMAT_DEBUG
-    if (rank == 0) then
-        write (*, *) 'Noda ndet after cdiag', ndet
-        write (*, *) 'Noda cidag mat diag values'
-        do idx1 = 1, ndet
-            ! if (real(mat(idx1, idx1)) > 1.0d-15) then
-            write (*, *) idx1, mat(idx1, idx1)
-            ! end if
-        end do
-    end if
-#endif
-!    if (rank == 0) then
+
 #ifdef HAVE_MPI
     call MPI_Barrier(MPI_COMM_WORLD, ierr)
 #endif
@@ -244,40 +113,9 @@ SUBROUTINE casci_ty(totsym)
     eigen(:) = 0.0d+00
     cir(:, :) = 0.0d+00
     cii(:, :) = 0.0d+00
-#ifdef BIG_MAT
-    if (rank == 0) then
-        eigen(1:nroot) = ecas(1:nroot) + ecore
-        cir(1:ndet, selectroot) = DBLE(mat(1:ndet, selectroot))
-        cii(1:ndet, selectroot) = DIMAG(mat(1:ndet, selectroot))
-    end if
-#ifdef HAVE_MPI
-    call MPI_Barrier(MPI_COMM_WORLD, ierr)
-    call MPI_Bcast(ndet, 1, MPI_INTEGER8, 0, MPI_COMM_WORLD, ierr)
-    write (*, *) 'ndet,rank', ndet, rank
-    call MPI_Barrier(MPI_COMM_WORLD, ierr)
-    write (*, *) 'selectroot,rank', selectroot, rank
-    call MPI_Barrier(MPI_COMM_WORLD, ierr)
-    write (*, *) 'nroot,rank', nroot, rank
-    call MPI_Barrier(MPI_COMM_WORLD, ierr)
-    call MPI_Bcast(eigen(1), nroot, MPI_REAL8, 0, MPI_COMM_WORLD, ierr)
-    write (*, *) 'eigen rank', rank, eigen
-    call MPI_Barrier(MPI_COMM_WORLD, ierr)
-    call MPI_Bcast(cir(1, selectroot), ndet, MPI_REAL8, 0, MPI_COMM_WORLD, ierr)
-    write (*, *) 'cir rank', rank, cir(1, selectroot)
-    call MPI_Barrier(MPI_COMM_WORLD, ierr)
-    call MPI_Bcast(cii(1, selectroot), ndet, MPI_REAL8, 0, MPI_COMM_WORLD, ierr)
-    write (*, *) 'cii rank', rank, cir(1, selectroot)
-#endif
-#else
     eigen(1:nroot) = ecas(1:nroot) + ecore
     cir(1:ndet, selectroot) = DBLE(mat(1:ndet, selectroot))
     cii(1:ndet, selectroot) = DIMAG(mat(1:ndet, selectroot))
-#endif
-#ifdef CASMAT_DEBUG
-    do loop_idx = 1, ndet
-        write (*, *) 'Noda cir check', loop_idx, real(mat(loop_idx, selectroot), 8)
-    end do
-#endif
     Deallocate (ecas)
     if (rank == 0) then ! Process limits for output
         write (*, *) 'debug4'
@@ -306,15 +144,7 @@ SUBROUTINE casci_ty(totsym)
             end do
         end do
     end if
-#ifdef BIG_MAT
-    ! Only the master process has a matrix named mat.
-    ! So the only master process deallocate this.
-    if (rank == 0) then
-        Deallocate (mat); Call memminus(KIND(mat), SIZE(mat), 2)
-    end if
-#else
     Deallocate (mat); Call memminus(KIND(mat), SIZE(mat), 2)
-#endif
 1000 end subroutine casci_ty
 
 ! ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/src/casmat.f90
+++ b/src/casmat.f90
@@ -18,7 +18,6 @@ SUBROUTINE casmat(mat)
     integer              :: phase, phase1, phase2
     real*8               :: nsign, i2r, i2i
     complex*16           :: cmplxint, mat0
-    integer              :: nprocs_for_mat
     integer, allocatable :: ridet(:), oc(:), vi(:)
 
     mat = 0.0d+00
@@ -31,14 +30,7 @@ SUBROUTINE casmat(mat)
     if (rank == 0) then ! Process limits for output
         write (*, *) 'allocated oc and vi', rank
     end if
-#ifdef BIG_MAT
-    ! If only the master process has a matrix named mat,
-    ! this subroutine will also excutes only by the master process.(So nprocs must be 1)
-    nprocs_for_mat = 1
-#else
-    nprocs_for_mat = nprocs
-#endif
-    Do i = rank + 1, ndet, nprocs_for_mat ! MPI parallelization (Distributed loop: static scheduling, per nprocs)
+    Do i = rank + 1, ndet, nprocs ! MPI parallelization (Distributed loop: static scheduling, per nprocs)
 
         occ = 0
         oc = 0
@@ -250,11 +242,7 @@ SUBROUTINE casmat(mat)
         write (*, '(A,I4)') 'Reduce mat(:,:)', rank
     end if
 #ifdef HAVE_MPI
-#ifdef BIG_MAT
-    ! If only the master rank execute casmat.f90, allreduce is not neccesarry.
-#else
     call MPI_Allreduce(MPI_IN_PLACE, mat(1, 1), ndet**2, MPI_COMPLEX16, MPI_SUM, MPI_COMM_WORLD, ierr)
-#endif
 #endif
 1000 end subroutine casmat
 


### PR DESCRIPTION
## このプルリクは何?
> プルリクの内容を記述してください

- 巨大な疎行列のデバッグ用に記述していたBIG_MATプリプロセッサとCASMAT_DEBUGプリプロセッサの削除
- casmat.f90の構造がわかりにくくなっていたため、このプルリクを作成しています

## 実装の内容
> 実装の内容を記述してください

- #ifdef BIG_MAT及び#ifdef CASMAT_DEBUG プリプロセッサ内部の処理と、それに使用した変数の削除

## (optional) 考慮事項
> 起こりうるバグなどがわかっている場合記述してください
