### PR TITLE
Because of ivo bug, delete indmo(i0) = i0

### DIFF
--- a/src/readorb_enesym_co.f90
+++ b/src/readorb_enesym_co.f90
@@ -450,7 +450,6 @@ SUBROUTINE readorb_enesym_co(filename) ! orbital energies in r4dmoin1
     do i0 = 1, nmo
         irpmo(i0) = dammo(indmo(i0))
         irpamo(i0) = dammo(indmo(i0))
-        indmo(i0) = i0
     end do
 
     if (rank == 0) then


### PR DESCRIPTION
## このプルリクは何?
> プルリクの内容を記述してください
- #15 のissueの内容に従ってプルリクを作成

削除したコードの行が入っているとバグを生むため削除
以下阿部先生のコメント

CASPT2プログラムで
readorb_enesym_co.f90の
       do i0 = 1, nmo
           irpmo(i0) = dammo(indmo(i0))
           irpamo(i0) = dammo(indmo(i0))
           indmo(i0) = i0
       end do
について、
           indmo(i0) = i0
の1行を永久削除してください。
casci,caspt2には影響なかったのですが、
(この前で定義されているindmorしか使わないので）
ivoにバグを与えるので、削除をお願いします。

## 実装の内容
> 実装の内容を記述してください

## (optional) 考慮事項
> 起こりうるバグなどがわかっている場合記述してください
