### PR TITLE
Change not to allocate 2-integrals variables in intra subroutine, and create subroutine named write_traint2_to_disk to write traint2 values.

### DIFF
--- a/src/intra.f90
+++ b/src/intra.f90
@@ -23,9 +23,8 @@ SUBROUTINE intra_1(spi, spj, spk, spl, fname)
 
     integer :: i, j, k, l, i1, j1, k1, l1, inew, jnew, knew, lnew
     integer :: ii, ji, ki, li, ie, je, ke, le
-    integer :: inz, nmx, ini(3), end(3), isp, isym, imo, ired
+    integer :: nmx, ini(3), end(3), isp, isym, imo
 
-    integer :: n_cnt
     logical :: is_opened
     thresd = 1.0d-15
 
@@ -257,10 +256,9 @@ SUBROUTINE intra_2(spi, spj, spk, spl, fname)
     complex*16              :: cint2
 
     integer :: i, j, k, l
-    integer ::i1, j1, k1, l1, inew, jnew, knew, lnew
-    integer :: ii, ji, ki, li, ie, je, ke, le, lkr0, kkr0
-    integer :: inz, nmx, ini(3), end(3), isp, isym, imo, ired, save
-    integer :: n_cnt
+    integer :: i1, j1, k1, l1, inew, jnew, knew, lnew
+    integer :: ii, ji, ki, li, ie, je, ke, le
+    integer :: nmx, ini(3), end(3), isp, isym, imo, save
 
     logical :: is_opened
     thresd = 1.0d-15
@@ -533,9 +531,8 @@ SUBROUTINE intra_3(spi, spj, spk, spl, fname)
     integer :: i, j, k, l
     integer :: initial_i, initial_j, initial_k, initial_l
     integer :: i1, j1, k1, l1, inew, jnew, knew, lnew
-    integer :: ii, ji, ki, li, ie, je, ke, le, lkr0, kkr0
-    integer :: inz, nmx, ini(3), end(3), isp, isym, imo, ired, save
-    integer :: n_cnt
+    integer :: ii, ji, ki, li, ie, je, ke, le
+    integer :: nmx, ini(3), end(3), isp, isym, imo
 
     logical :: is_opened
     thresd = 1.0d-15
@@ -725,23 +722,7 @@ SUBROUTINE intra_3(spi, spj, spk, spl, fname)
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
     open (1, file=trim(fname), status='replace', form='unformatted')
-    n_cnt = 0
-    Do l = li, le
-        Do k = ki, ke
-            Do j = ji, je
-                Do i = ii, ie
-                    if (ABS(traint2(i, j, k, l)) > thresd) then
-                        if (mod(n_cnt, nprocs) == rank) then
-                            write (1) i, j, k, l, traint2(i, j, k, l)
-                        end if
-                        n_cnt = n_cnt + 1
-                        ! write (1, '(4I4, 2e2.1)') i, j, k, l, traint2(i, j, k, l)
-                    end if
-                End do
-            End do
-        End do
-    End do
-
+    call write_traint2_to_disk(ii, ie, ji, je, ki, ke, li, le, traint2(ii:ie, ji:je, ki:ke, li:le), thresd)
     close (1)
 
     traint2 = 0.0d+00


### PR DESCRIPTION
## このプルリクは何?
> プルリクの内容を記述してください
- subroutine intraにて2電子積分を読むところで無駄なmemory  allocateがあったので使わないように変更
- 積分変換後の2電子積分を書き込む部分がすべて同じ処理だったのでsubroutine化した(subroutine名: write_traint2_to_disk)

## 実装の内容
> 実装の内容を記述してください
### メモリについて
- 2電子積分のインデックスi,j,k,l及び2電子積分の値cint2を約5.0^10 bitも強制的にallocateするようになっていたので、allocateしないように変更
- 変更に伴い以前はi0=i(inz)などと代入してi0を今の2電子積分のiのインデックスとしていたが、ファイルからi,j,k,l,cintを1つずつ読んで処理を繰り返すように変更
- 前のi0をi,j0をj,k0をk,l0をl,cint2_0をcint2という変数名に変更
- i0,j0,k0,l0,cint2_0,その他現在使用していない変数を削除
- クラマースペアに対して複数回積分変換をする必要がある部分において、クラマースペアではなくもとのindexがほしい場合があり、それについてはinitial_i,initial_j,initial_k,initial_lという変数を追加してその変数を使用するように変更

## 計算の確認
H2O,CAS(6,2),MPI:8coreで確認し全く同じ結果が得られた
分子研: 
/home/users/sm2/noda/debug_run_results_history/h2o-intra-test/relqc01-no-allocate-prev
が変更前で以下の結果になった
e2a      =    -0.2841501699E-06 a.u.
e2b      =    -0.5851248112E-03a.u.
e2c      =    -0.2562014561E-03a.u.
e2d      =    -0.4292174222E-02a.u.
e2e      =    -0.9953917255E-02a.u.
e2f      =    -0.2111822881E-01a.u.
e2g      =    -0.9299356587E-01a.u.
e2h      =    -0.1686691524E+00a.u.
Total second order energy is             -0.297868648954466 a.u.
Total energy is            -76.417830177837686 a.u.

/home/users/sm2/noda/debug_run_results_history/h2o-intra-test/relqc01-no-allocate-all-subroutine-write-procedure
が変更後で以下の結果になった
e2a      =    -0.2841501699E-06 a.u.
e2b      =    -0.5851248112E-03a.u.
e2c      =    -0.2562014561E-03a.u.
e2d      =    -0.4292174222E-02a.u.
e2e      =    -0.9953917255E-02a.u.
e2f      =    -0.2111822881E-01a.u.
e2g      =    -0.9299356587E-01a.u.
e2h      =    -0.1686691524E+00a.u.
Total second order energy is             -0.297868648954466 a.u.
Total energy is            -76.417830177837686 a.u.


## (optional) 考慮事項
> 起こりうるバグなどがわかっている場合記述してください
