### PR TITLE
Fix: close when goto 100 in intra[1-3]

### DIFF
--- a/src/intra.f90
+++ b/src/intra.f90
@@ -219,12 +219,9 @@ SUBROUTINE intra_1(spi, spj, spk, spl, fname)
 
     goto 100
 10  write (*, *) 'error opening file'
-    inquire (1, opened=is_opened)
-    if (is_opened .eqv. .true.) then
-        close (1)
-    end if
-
 100 continue
+    close (1)
+
     deallocate (traint2); Call memminus(KIND(traint2), SIZE(traint2), 2)
 
     deallocate (indsym); Call memminus(KIND(indsym), SIZE(indsym), 1)
@@ -490,14 +487,9 @@ SUBROUTINE intra_2(spi, spj, spk, spl, fname)
 
     goto 100
 10  write (*, *) 'error opening file'
-    inquire (1, opened=is_opened)
-    if (is_opened .eqv. .true.) then
-        close (1)
-    end if
-
 100 continue
+    close (1)
     deallocate (traint2); Call memminus(KIND(traint2), SIZE(traint2), 2)
-
     deallocate (indsym); Call memminus(KIND(indsym), SIZE(indsym), 1)
     deallocate (nsym); Call memminus(KIND(nsym), SIZE(nsym), 1)
 
@@ -758,17 +750,12 @@ SUBROUTINE intra_3(spi, spj, spk, spl, fname)
     goto 100 ! No error in intra3
 
 10  write (*, *) 'error opening file'
-    inquire (1, opened=is_opened)
-    if (is_opened .eqv. .true.) then
-        close (1)
-    end if
-    goto 101
-
 100 continue
+    close (1)
+
     if (rank == 0) write (*, *) 'read and write file properly. filename : ', trim(fname)
 101 continue
     deallocate (traint2); Call memminus(KIND(traint2), SIZE(traint2), 2)
-
     deallocate (indsym); Call memminus(KIND(indsym), SIZE(indsym), 1)
     deallocate (nsym); Call memminus(KIND(nsym), SIZE(nsym), 1)
 


### PR DESCRIPTION
## このプルリクは何?
> プルリクの内容を記述してください

- [intra.f90](https://github.com/kohei-noda-qcrg/dirac_caspt2/blob/ec8f04be86abfbd40eef68499547cc218d3af447/src/intra.f90#L758-L765)において、intra3のファイルクローズが正常にできていなかったため、修正したプルリクです

## 実装の内容
> 実装の内容を記述してください

- errorかそうでないかに関わらずfile番号1番をintraの終わりに必ずcloseするようにしました
- 近々#25 にある通りfile番号を管理するためのソフトウェアインターフェースを作成して、装置番号の管理を楽にできるように変えます:yum:

## (optional) 考慮事項
> 起こりうるバグなどがわかっている場合記述してください
