### PR TITLE
Correct errors in MPI count implementation

### DIFF
--- a/src/module_mpi.f90
+++ b/src/module_mpi.f90
@@ -159,7 +159,11 @@ contains
                 call check_ierr(ierr)
             end do
         else ! no limit
-            call MPI_Allreduce(MPI_IN_PLACE, mat, size(mat), MPI_COMPLEX16, op, MPI_COMM_WORLD, ierr)
+            if (rank == root_rank) then
+                call MPI_Reduce(MPI_IN_PLACE, mat, size(mat), MPI_COMPLEX16, op, root_rank, MPI_COMM_WORLD, ierr)
+            else
+                call MPI_Reduce(mat, mat, size(mat), MPI_COMPLEX16, op, root_rank, MPI_COMM_WORLD, ierr)
+            end if
             call check_ierr(ierr)
         end if
 


### PR DESCRIPTION
## このプルリクは何?
> プルリクの内容を記述してください

- #68 の修正プルリクです
  - do loopのステップ数および送受信する要素数の計算式を訂正しました
  - 訂正に伴い、不要なidx_endを削除しました

## 実装の内容
> 実装の内容を記述してください

## (optional) 考慮事項
> 起こりうるバグなどがわかっている場合記述してください
