### PR TITLE
Create symbolic links instead of copying files to a scratch directory (MDCIN*, MRCONEE)

### DIFF
--- a/tools/dcaspt2_input
+++ b/tools/dcaspt2_input
@@ -138,12 +138,13 @@ def copy_essential_files_to_scratch_dir(args: "argparse.Namespace", input_file_p
         shutil.copy(input_file_path, scratch_dir)
     os.rename(os.path.join(scratch_dir, os.path.basename(input_file_path)), os.path.join(scratch_dir, "active.inp"))  # Rename the input file to "active.inp"
     if integrals_dir != scratch_dir:  # If the 1-2 integrals file is not in the temporary directory, copy the 1-2 integrals file to the temporary directory
-        shutil.copy(os.path.join(integrals_dir, "MDCINT"), scratch_dir)
-        shutil.copy(os.path.join(integrals_dir, "MRCONEE"), scratch_dir)
+        # Create a symbolic link to the 1-2 integrals file
+        os.symlink(os.path.join(integrals_dir, "MDCINT"), os.path.join(scratch_dir, "MDCINT"))
+        os.symlink(os.path.join(integrals_dir, "MRCONEE"), os.path.join(scratch_dir, "MRCONEE"))
         if args.ivo:
             shutil.copy(os.path.join(integrals_dir, "DFPCMO"), scratch_dir)
         for file in glob.glob(os.path.join(integrals_dir, "MDCINX*")):
-            shutil.copy(file, scratch_dir)
+            os.symlink(file, os.path.join(scratch_dir, os.path.basename(file)))
         print("log : Copied 1-2 integral files to the scratch directory")
     return None
 


### PR DESCRIPTION
## このプルリクは何?
> プルリクの内容を記述してください

- これまでは1,2電子積分をスクラッチディレクトリにコピーしてから計算を開始していたが、基底関数が大きくなるとコピーに時間がかかりすぎる、コピー前後のファイルが両方保存されるのでディスクが圧迫されるなどといった問題があった
→この問題点を解決するためのプルリクです

## 実装の内容
> 実装の内容を記述してください

- symbolic linkを使うことでほぼコピーコストをかけずに計算を行えるようにしました

## (optional) 考慮事項
> 起こりうるバグなどがわかっている場合記述してください

- 今まではコピーしていたので、コピーが終わったらすぐに元のMDCINTが削除されたり、MDCINTがあるディレクトリが移動されてしまっても問題なく計算できていたが、symbolic linkだと削除や移動をされるとファイルがなくなったり、見えなくなったりするのでファイルが見つからないというエラーが発生します
 