### PR TITLE
Skip the CASPT2 calculation if inact or secondary is zero.

### DIFF
--- a/src/r4dcaspt2_tra.f90
+++ b/src/r4dcaspt2_tra.f90
@@ -84,6 +84,11 @@ PROGRAM r4dcaspt2_tra   ! DO CASPT2 CALC WITH MO TRANSFORMATION
         if (ras3_size /= 0) print *, "RAS3 =", ras3_list
     end if
 
+    if (ninact == 0 .and. nsec == 0) then
+        if (rank == 0) print *, "The CASPT2 energy cannot be defined when ninact = 0 and nsec = 0."
+        stop
+    end if
+
     ! Read MRCONEE file (orbital energies, symmetries and multiplication tables)
     if (rank == 0) print *, ' ENTER READ MRCONEE'
     filename = 'MRCONEE'


### PR DESCRIPTION
## このプルリクは何?
> プルリクの内容を記述してください
- ninactもnsecも0のとき、CASPT2の計算自体をスキップするように変更(return codeは0)
- ninactかnsecのどちらか片方が0のとき、CASPT2計算は可能だが部分空間によっては計算の必要がないのでスキップするように変更

## 実装の内容
> 実装の内容を記述してください

- ninactやnsecの値を見て、部分空間ごとに判定条件を課すようにした
https://github.com/RQC-HU/dirac_caspt2/blob/d3ce5f5409f74b99f2fa2289d1272c4eea6ec5d6/src/r4dcaspt2_tra.f90#L202-L205
- ninactとnsecの両方が0の場合、CASPT2計算を始める前に止めるようにした
https://github.com/RQC-HU/dirac_caspt2/blob/d3ce5f5409f74b99f2fa2289d1272c4eea6ec5d6/src/r4dcaspt2_tra.f90#L87-L90

## (optional) 考慮事項
> 起こりうるバグなどがわかっている場合記述してください

- CASPT2計算自体を止めるninact=0 .and. nsec=0のとき、return codeについて0以外にして、明示的にエラーとして扱うべきか？