### PR TITLE
Fixed recalculated CASCI energy was incorrect due to the sign being reversed.

### DIFF
--- a/src/e0test.f90
+++ b/src/e0test.f90
@@ -213,7 +213,7 @@ SUBROUTINE e0test ! test to calculate <i|H|i>=Ei i is solution of the CASCI
                         Call dim2_density(ii, jj, kk, ll, dr, di)
                     end if
                     dens = DCMPLX(dr, di)
-                    energy(iroot, 4) = energy(iroot, 4) - dens*cmplxint
+                    energy(iroot, 4) = energy(iroot, 4) + dens*cmplxint
 
                     if (j == k) then
                         if (realonly%is_realonly()) then


### PR DESCRIPTION
## このプルリクは何?
> プルリクの内容を記述してください

- #100 を解決
- https://github.com/kohei-noda-qcrg/dirac_caspt2/issues/100#issuecomment-1660393612 にあるように、energy4に値を足し引きする際の符号が反転していたせいで発生していた問題だった
- 符号を入れ替えることで解決

## 実装の内容
> 実装の内容を記述してください

## (optional) 考慮事項
> 起こりうるバグなどがわかっている場合記述してください
