### PR TITLE
Fix dcaspt2 get option has unexpected behavior

### DIFF
--- a/tools/dcaspt2_input
+++ b/tools/dcaspt2_input
@@ -61,9 +61,10 @@ Wildcard is available.\n\
     parser.add_argument(
         "--scratch",
         dest="scratchdir",
+        type=str,
         help="Set the scratch directory. Add the subdirectory to the specified directory.\n(e.g.) --scratch /home/username/scratch \n=> Create /home/username/scratch/active_2020-01-01_12-34-56 directory.\n[default: ~/dcaspt2_scratch]",
     )
-    parser.add_argument("--scratchfull", dest="scratchfull", help="Set the scratch directory. Use the specified directory as the scratch directory.\n[default: None]")
+    parser.add_argument("--scratchfull", dest="scratchfull", type=str, help="Set the scratch directory. Use the specified directory as the scratch directory.\n[default: None]")
     parser.add_argument(
         "--only-casci", dest="onlycasci", action="store_true", help="Run CASCI calculation only. [default: False]\nThis option cannot be used at the same time with --skip-casci option."
     )


### PR DESCRIPTION
## このプルリクは何?
> プルリクの内容を記述してください

- #104 を修正
- 引数のパース中にエラーが発生した場合、dcaspt2 --helpを実行したときのメッセージを表示させると共に、ヘルプメッセージを確認して再実行するように表示するように変更

## 実装の内容
> 実装の内容を記述してください

- ExitWithHelpArgumentParserというargparse.ArgumentParserを継承したカスタムクラスを作成
- error関数内でprint_helpすることで、ヘルプメッセージを表示させる
https://github.com/RQC-HU/dirac_caspt2/blob/8b91c2d0fdb06b150b2cd131970011c1d5386938/tools/dcaspt2_input#L15-L21

- --getオプションのmetavarをダブルクォーテーションで囲んだり、helpにダブルクォーテーションやシングルクォーテーションで囲むように指示するようにした
https://github.com/RQC-HU/dirac_caspt2/blob/8b91c2d0fdb06b150b2cd131970011c1d5386938/tools/dcaspt2_input#L50-L60

## (optional) 考慮事項
> 起こりうるバグなどがわかっている場合記述してください
