### PR TITLE
Fixed a bug in mpi parallel where all processes did not terminate if consistency_check failed.

### DIFF
--- a/src/r4divo.f90
+++ b/src/r4divo.f90
@@ -85,7 +85,7 @@ PROGRAM r4divo_co   ! DO IVO CALC ONLY FOR SMALL BASIS SETS
     call read_mrconee(filename)
 
     ! Check consistency of IVO input and DFPCMO file.
-    if (rank == 0) call ivo_consistency_check
+    call ivo_consistency_check
 
     call check_realonly
     ! Create UTChem type MDCINT file from Dirac MDCINT file


### PR DESCRIPTION
## このプルリクは何?
> プルリクの内容を記述してください

- MPIでIVOを並列実行した場合、module_ivo_consistency_check.f90でエラーになり終了した場合、rank=0以外のプロセスはチェックしないのでMPI_Barrierの待ち合わせが発生してプロセスが止まらなくなる問題を解消

## 実装の内容
> 実装の内容を記述してください

## (optional) 考慮事項
> 起こりうるバグなどがわかっている場合記述してください
