### PR TITLE
Add custom target and command to retrieve git commit hash

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,23 +76,18 @@ add_subdirectory(test)
 configure_file(${PROJECT_SOURCE_DIR}/tools/dcaspt2_input ${EXECUTABLE_OUTPUT_PATH}/dcaspt2 COPYONLY)
 install(PROGRAMS ${EXECUTABLE_OUTPUT_PATH}/dcaspt2 DESTINATION ${CMAKE_INSTALL_PREFIX})
 
-# Git commit hash
-set(git_hash "unknown")  # Default value
+# Create a custom target named commit_hash
+add_custom_target(commit_hash ALL)
 
-# If .git/HEAD exists, get the commit hash
-if(EXISTS "${PROJECT_SOURCE_DIR}/.git/HEAD")
-  file(STRINGS "${PROJECT_SOURCE_DIR}/.git/HEAD" git_head)
-
-  if(git_head MATCHES "ref: ")
-    string(REGEX REPLACE "ref: " "" git_head "${git_head}")
-    file(STRINGS "${PROJECT_SOURCE_DIR}/.git/${git_head}" git_hash LIMIT_COUNT 1)
-  else()
-    set(git_hash "${git_head}")
-  endif()
-
-  message(STATUS "Git commit hash: ${git_hash}")
-endif()
-
-# Save the git commit hash to a file
-file(WRITE ${EXECUTABLE_OUTPUT_PATH}/.commit_hash "${git_hash}")
+# Add a custom command to the target (commit_hash)
+add_custom_command(
+  TARGET commit_hash
+  PRE_BUILD
+  COMMAND ${CMAKE_COMMAND}
+  -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
+  -DEXECUTABLE_OUTPUT_PATH=${EXECUTABLE_OUTPUT_PATH}
+  -DPROJECT_SOURCE_DIR=${PROJECT_SOURCE_DIR}
+  -P ${PROJECT_SOURCE_DIR}/cmake/commit_hash.cmake
+  ALWAYS
+)
 install(FILES ${EXECUTABLE_OUTPUT_PATH}/.commit_hash DESTINATION ${CMAKE_INSTALL_PREFIX})

--- a/cmake/commit_hash.cmake
+++ b/cmake/commit_hash.cmake
@@ -1,0 +1,20 @@
+message(STATUS "Getting git hash")
+message(STATUS "commit_hash.cmake PROJECT_SOURCE_DIR: ${PROJECT_SOURCE_DIR}")
+message(STATUS "commit_hash.cmake EXECUTABLE_OUTPUT_PATH: ${EXECUTABLE_OUTPUT_PATH}")
+message(STATUS "commit_hash.cmake CMAKE_INSTALL_PREFIX: ${CMAKE_INSTALL_PREFIX}")
+set(git_hash "unknown") # Default value
+
+if(EXISTS "${PROJECT_SOURCE_DIR}/.git/HEAD")
+    file(STRINGS "${PROJECT_SOURCE_DIR}/.git/HEAD" git_head)
+
+    if(git_head MATCHES "ref: ")
+        string(REGEX REPLACE "ref: " "" git_head "${git_head}")
+        file(STRINGS "${PROJECT_SOURCE_DIR}/.git/${git_head}" git_hash LIMIT_COUNT 1)
+    else()
+        set(git_hash "${git_head}")
+    endif()
+else()
+    set(git_hash "unknown")
+endif()
+
+file(WRITE ${EXECUTABLE_OUTPUT_PATH}/.commit_hash "${git_hash}")


### PR DESCRIPTION
## このプルリクは何?
> プルリクの内容を記述してください

- #150 を修正
- https://qiita.com/moinslut/items/99723be2308dc6dcb813 を参考にカスタムターゲットを追加して、そのカスタムターゲットに対してPRE_BUILDのカスタムコマンドを作成し、新しく作った[cmake/commit_hash.cmake](https://github.com/RQC-HU/dirac_caspt2/blob/bd79646f20fd2e45af2b83a5bf46d9e32d460955/cmake/commit_hash.cmake)を実行することで、ビルドするたびにコミットハッシュを取得する処理が走るようになった

## 実装の内容
> 実装の内容を記述してください

## (optional) 考慮事項
> 起こりうるバグなどがわかっている場合記述してください

- https://stackoverflow.com/a/43206544 にあるように、ビルドターゲットをデフォルト以外にされるとコミットハッシュの取得処理が走らない。ただし本プロジェクトでは使用しないはずなので、ビルドターゲットを変更された場合の処理は加えていない。
  - プログラムがさらに複雑になった場合に対応を考える