### PR TITLE
Fix nroot parameter description in README files

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -323,7 +323,7 @@ noccg       : The number of occupied spinors (gerade)
 noccu       : The number of occupied spinors (ungerade)
 
 [optional parameters]
-nroot       : the number of roots (default: 10, max: 500, if the number of CASCI/RASCI configuration is less than 10, it will be replaced by the number of CASCI/RASCI configuration)
+nroot       : the number of roots (default: 10, max: 500, if the number of CASCI/RASCI configuration is less than nroot, nroot will be replaced by the number of CASCI/RASCI configuration)
 selectroot  : which root do you want to calculate RASPT2/CASPT2 energy? (default: 1, max: 500, the lowest root)
 eshift      : for real shift (default: 0)
 ras1        : RAS1 spinor list (row 1)and the maximum number of hole allowed in ras1(row 2)

--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ noccg       : The number of occupied MO (gerade)
 noccu       : The number of occupied MO (ungerade)
 
 [optional parameters]
-nroot       : the number of roots (default: 10, max: 500, if the number of CASCI/RASCI configuration is less than 10, it will be replaced by the number of CASCI/RASCI configuration)
+nroot       : the number of roots (default: 10, max: 500, if the number of CASCI/RASCI configuration is less than nroot, nroot will be replaced by the number of CASCI/RASCI configuration.)
 selectroot  : which root do you want to calculate RASPT2/CASPT2 energy? (default: 1, max: 500, the lowest root)
 eshift      : for real shift (default: 0)
 ras1        : RAS1 spinor list (row 1)and the maximum number of hole allowed in ras1(row 2)


### PR DESCRIPTION
## このプルリクは何?
> プルリクの内容を記述してください

- nrootの説明が間違っていたので修正
  - CASCI/RASCI配置の数がnrootで指定した数より小さいとき、nroot=10になると書いていたが、nroot=CASCI/RASCI配置の数になるのが正しかった
https://github.com/RQC-HU/dirac_caspt2/blob/456f020287b92862927b4fb88899eecb25559fcb/src/search_cas_configuration.f90#L174-L183
## 実装の内容
> 実装の内容を記述してください

## (optional) 考慮事項
> 起こりうるバグなどがわかっている場合記述してください
