### PR TITLE
Use y, m, d variables in function ymd2day for code readability.

### DIFF
--- a/src/module_time.f90
+++ b/src/module_time.f90
@@ -173,7 +173,7 @@ contains
         m = month_to_day(time%month, is_leap_year(time%year))
         d = time%date - 1
 
-        ymd2day = year_to_day(time%year) + month_to_day(time%month, is_leap_year(time%year)) + time%date - 1
+        ymd2day = y + m + d
     end function ymd2day
 
     function year_to_day(year)


### PR DESCRIPTION
## このプルリクは何?
> プルリクの内容を記述してください

- 年月日から0001/01/01からの経過日数を計算するfunction ymd2dayについて、年、月、日を日に変換した変数y,m,dを定義して計算していたが、以下のように全体の経過日数の計算には使っていなかった
https://github.com/RQC-HU/dirac_caspt2/blob/f58771a8d0dee6938179c028f10bb3b01c60ff4b/src/module_time.f90#L172-L176
- したがってy,m,dを使用するように変更した
https://github.com/RQC-HU/dirac_caspt2/blob/0e89faef2cf7087fcb30fc9ff3620c97e47f359d/src/module_time.f90#L172-L176

## 実装の内容
> 実装の内容を記述してください

## (optional) 考慮事項
> 起こりうるバグなどがわかっている場合記述してください
