### PR TITLE
fix: 3-digit zero-fill for milliseconds display

### DIFF
--- a/tools/dcaspt2_input
+++ b/tools/dcaspt2_input
@@ -388,7 +388,7 @@ Scratch directory : {scratch_dir}\n\
 Output file : {output_file_path}\n\
 Calculation started at : {start_time_str}\nCalculation finished at : {end_time_str}\n\
 Elapsed time (sec) : {(end_time - start_time).total_seconds():.4f} sec\n\
-Elapsed time : {days} day {hours} hour {mins} min {secs} sec {millisecs} millisecond\n\
+Elapsed time : {days} day {hours} hour {mins} min {secs} sec {millisecs:03} millisecond\n\
 dirac-caspt2 version (commit hash) : {version}\n"
             return finished_message
 


### PR DESCRIPTION
## このプルリクは何?
> プルリクの内容を記述してください

- Elapsed timeのミリ秒表示について、2.052秒の場合 2 sec 52 millisecondと表示されるが、Excel等でグラフを作るときに注意しないと間違えて2.52秒にしてしまう可能性がある
- 左の桁についてゼロ埋めすることで解消します

## 実装の内容
> 実装の内容を記述してください

- f-stringの0埋めの記法を使って数値を右詰めして3桁で0埋めする
https://note.nkmk.me/python-zero-padding/#format-f:~:text=Python3.6%E3%81%8B%E3%82%89%E3%81%AFf%E6%96%87%E5%AD%97%E5%88%97%EF%BC%88f%2Dstrings%EF%BC%89%E3%82%82%E4%BD%BF%E7%94%A8%E5%8F%AF%E8%83%BD%E3%80%82%E3%82%88%E3%82%8A%E7%B0%A1%E6%BD%94%E3%81%AB%E6%9B%B8%E3%81%91%E3%82%8B%E3%80%82
https://github.com/RQC-HU/dirac_caspt2/blob/5e3894712c1d174b18fa15baa8f6d8612110f4c8/tools/dcaspt2_input#L391

## (optional) 考慮事項
> 起こりうるバグなどがわかっている場合記述してください
