### PR TITLE
test_generator fix: change default_path and default_answer_path

### DIFF
--- a/tools/dcaspt2_test_generator
+++ b/tools/dcaspt2_test_generator
@@ -36,8 +36,8 @@ class DIRACFiles:
     def ask_dirac_files(self, default_answer_path: Path) -> Path:
         # DIRAC input, mol and output files
         program_name = "DIRAC"
-        self.output_file_path = ask_output_file_path(program_name=program_name, default_path=self.input_file_path.parent)
-        self.input_file_path = ask_input_file_path(program_name=program_name, default_path=default_answer_path)
+        self.output_file_path = ask_output_file_path(program_name=program_name, default_path=default_answer_path)
+        self.input_file_path = ask_input_file_path(program_name=program_name, default_path=self.output_file_path.parent)
         self.mol_file_path = ask_mol_file_path(program_name=program_name, default_path=self.input_file_path.parent)
 
     def create_dirac_dir_and_copy_files(self):
@@ -200,9 +200,9 @@ def main():
 
         # Ask for the path of the integrals file
         integral_files = IntegralFiles()
-        integral_files.ask_dirac_integrals_directory(default_dir=ref_parent_dir)
+        integral_files.ask_dirac_integrals_directory(default_dir=input_file_path.parent)
         dirac_files = DIRACFiles(data_directory=Path.joinpath(test_dir, "dirac_data"))
-        dirac_files.ask_dirac_files(default_answer_path=ref_parent_dir)
+        dirac_files.ask_dirac_files(default_answer_path=integral_files.integrals_file_path)
 
         # mkdir the test directory
         test_dir.mkdir(parents=True, exist_ok=True)
@@ -242,13 +242,13 @@ def main():
         input_file_path = ask_input_file_path(program_name="DIRAC-IVO", default_path=ref_parent_dir)
 
         # Ask for the DFPCMO and DFPCMONEW files
-        dfpcmo_file_path = ask_general_file_path(program_name="DIRAC-IVO", file_type="DFPCMO", default_path=ref_parent_dir)
-        ref_dfpcmonew_file_path = ask_general_file_path(program_name="DIRAC-IVO", file_type="DFPCMONEW", default_path=ref_parent_dir)
+        dfpcmo_file_path = ask_general_file_path(program_name="DIRAC-IVO", file_type="DFPCMO", default_path=input_file_path.parent)
+        ref_dfpcmonew_file_path = ask_general_file_path(program_name="DIRAC-IVO", file_type="DFPCMONEW", default_path=dfpcmo_file_path.parent)
         # Ask for the path of the integrals file
         integral_files = IntegralFiles()
-        integral_files.ask_dirac_integrals_directory(default_dir=ref_parent_dir)
+        integral_files.ask_dirac_integrals_directory(default_dir=ref_dfpcmonew_file_path.parent)
         dirac_files = DIRACFiles(data_directory=Path.joinpath(test_dir, "dirac_data"))
-        dirac_files.ask_dirac_files(default_answer_path=ref_parent_dir)
+        dirac_files.ask_dirac_files(default_answer_path=integral_files.integrals_file_path)
 
         # mkdir the test directory
         test_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## このプルリクは何?
> プルリクの内容を記述してください
- test generatorの回答のデフォルト回答パスに誤りがあったので訂正
  - またデフォルト回答パスが常に前回の回答のパスになったほうが入力しやすいのでそのような構造に変更

## 何が誤っていたか
- DIRACのアウトプットを聞くときにまだ答えていないインプットのパスをデフォルト値にしていたため、参照エラーが発生していた
```
$ ./tools/dcaspt2_test_generator 
Welcome to the DIRAC-CASPT2 test generator!
This tool will generate a test for you to run on the DIRAC-CASPT2 program.
Please answer the following questions to generate the test.
? What type of test would you like to generate? CASPT2 energy test
INFO : Generating CASPT2 energy test...
? What type of test would you like to generate? fast(dev), 1-10 sec
INFO : Reference test type: fast(dev), 1-10 sec
? Please enter the name of the test directory. mdcint_scheme_6_dirac23_c32h_n2_dev
INFO : Test directory name: mdcint_scheme_6_dirac23_c32h_n2_dev
? Please enter the path of the DIRAC-CASPT2 output file. /home/noda/develop/dirac_caspt2_new/test/dev/c32h_n2_dev/reference.c32h_n2_dev.out
INFO : DIRAC-CASPT2 output path: /home/noda/develop/dirac_caspt2_new/test/dev/c32h_n2_dev/reference.c32h_n2_dev.out
? Please enter the path of the DIRAC-CASPT2 input file. /home/noda/test/dirac/mdcint/N2/scheme6/active.inp
INFO : DIRAC-CASPT2 input path: /home/noda/test/dirac/mdcint/N2/scheme6/active.inp
? Please enter the directory of the DIRAC integrals files (MRCONEE, MDCINT, MDCINXXXX1, ...) are stored. /home/noda/test/dirac/mdcint/N2/scheme6/
INFO : DIRAC integrals directory: /home/noda/test/dirac/mdcint/N2/scheme6
Traceback (most recent call last):
  File "/home/noda/develop/dirac_caspt2_new/./tools/dcaspt2_test_generator", line 340, in <module>
    main()
  File "/home/noda/develop/dirac_caspt2_new/./tools/dcaspt2_test_generator", line 205, in main
    dirac_files.ask_dirac_files(default_answer_path=ref_parent_dir)
  File "/home/noda/develop/dirac_caspt2_new/./tools/dcaspt2_test_generator", line 39, in ask_dirac_files
    self.output_file_path = ask_output_file_path(program_name=program_name, default_path=self.input_file_path.parent)
                                                                                         ^^^^^^^^^^^^^^^^^^^^
AttributeError: 'DIRACFiles' object has no attribute 'input_file_path'
```

## 実装の内容
> 実装の内容を記述してください

## (optional) 考慮事項
> 起こりうるバグなどがわかっている場合記述してください
