### PR TITLE
Delete --no-scratch option

### DIFF
--- a/tools/dcaspt2_input
+++ b/tools/dcaspt2_input
@@ -209,7 +209,8 @@ def copy_essential_files_to_scratch_dir(args: "argparse.Namespace", input_file_p
         scratch_input_file_path.symlink_to(input_file_path)
         restart_file = input_file_dir / "caspt2_restart"
         if restart_file.exists():
-            shutil.copy(restart_file, scratch_dir)
+            scratch_restart_file_path = scratch_dir / "caspt2_restart"
+            scratch_restart_file_path.symlink_to(restart_file)
     if integrals_dir != scratch_dir:
         # Create a symbolic link to the 1-2 integrals file
         scratch_mrconee_path = scratch_dir / "MRCONEE"


### PR DESCRIPTION
## このプルリクは何?
> プルリクの内容を記述してください

- dcaspt2スクリプトのリファクタリング
  - --no-scratchオプションは元々MDCINTのコピーコスト削減などの理由で導入されたオプションだったが、symlinkを使っている今はもう不必要なオプションなので削除
  - --scratchfullオプションを使うと/homeなどをスクラッチディレクトリとして指定できてしまう問題の修正。もしsudoなどを使ったりrootユーザーだったりするなどの理由でシステムのディレクトリを削除してしまうと大問題なので$HOME以上のディレクトリは--scratchfullオプションで指定できないようにした
  
## 実装の内容
> 実装の内容を記述してください

## (optional) 考慮事項
> 起こりうるバグなどがわかっている場合記述してください
