### PR TITLE
deprecate skip_mdcint

### DIFF
--- a/src/module_global_variables.f90
+++ b/src/module_global_variables.f90
@@ -30,7 +30,7 @@ MODULE module_global_variables
     integer         :: ras1_start, ras2_start, ras3_start
     integer         :: ras1_size = 0, ras2_size = 0, ras3_size = 0
     integer         :: ras1_max_hole, ras3_max_elec, min_hole_ras1 = 0
-    logical         :: skip_mdcint = .false., enable_restart = .false.
+    logical         :: enable_restart = .false.
     integer, allocatable :: ras1_list(:), ras2_list(:), ras3_list(:)
     integer         :: nhomo = 0  ! Default value of nhomo is zero. If you want to specify the value, please use the input file.
     integer, parameter :: max_ras_spinor_num = 200, max_i4 = huge(0_4) ! 4byte integer max value

--- a/src/r4dcasci.f90
+++ b/src/r4dcasci.f90
@@ -60,15 +60,10 @@ subroutine r4dcasci   ! DO CASCI CALC IN THIS PROGRAM!
     end if
 
     ! Read around the MDCINT file and determine if the imaginary part of the 2-electron integral is written or not.
-    if (skip_mdcint) then
-        if (rank == 0) print *, "Skip create_newmdcint (Activated skip_mdcint option by user input file)"
-        call get_mdcint_filename(0)
-    else
-        call get_current_time_and_print_diff(start_time, end_time); start_time = end_time
-        ! Create UTChem type MDCINT file from Dirac MDCINT file
-        call create_newmdcint
-        call get_current_time_and_print_diff(start_time, end_time); start_time = end_time
-    end if
+    call get_current_time_and_print_diff(start_time, end_time); start_time = end_time
+    ! Create UTChem type MDCINT file from Dirac MDCINT file
+    call create_newmdcint
+    call get_current_time_and_print_diff(start_time, end_time); start_time = end_time
 
     ! Read UTChem type MDCINT files and expands the 2-electron integral in memory
     Call readint2_casci(mdcintnew, nuniq)

--- a/src/read_input_module.f90
+++ b/src/read_input_module.f90
@@ -172,9 +172,6 @@ contains
         case (".minholeras1")
             call read_an_integer(unit_num, ".minholeras1", 0, input_intmax, min_hole_ras1)
 
-        case (".skip_mdcint")
-            skip_mdcint = .true.
-
         case (".nocc")
             if (inversion) call err_ivo_input
             call read_an_integer(unit_num, ".nocc", 0, input_intmax, occ_mo_num(1))


### PR DESCRIPTION
## このプルリクは何?
> プルリクの内容を記述してください

- インプットで指定できるようにしていた skip_mdcint オプションを廃止します
- 他のPRでMDCINTNEWがもともとあるときはcraete_mdcint()を呼ばないように変更することでskip_mdcintを指定する必要がないようにする予定です

## 実装の内容
> 実装の内容を記述してください

## (optional) 考慮事項
> 起こりうるバグなどがわかっている場合記述してください
