### PR TITLE
add .countndet option

### DIFF
--- a/src/dcaspt2_run_subprograms.f90
+++ b/src/dcaspt2_run_subprograms.f90
@@ -23,6 +23,11 @@ subroutine dcaspt2_run_subprograms
     call read_mrconee(filename)
     call check_realonly
 
+    if (docountndet) then
+        call search_cas_configuration ! If docountndet is true, only search the number of CASCI configurations and print them
+        return ! skip subprograms if docountndet is true
+    end if
+
     if (doivo) then
         call r4divo_co
     end if

--- a/src/module_global_variables.f90
+++ b/src/module_global_variables.f90
@@ -40,7 +40,7 @@ MODULE module_global_variables
     logical         :: inversion = .false., no_inversion = .false., is_scheme_set = .false.
     logical         :: debug = .false. ! debugprint option
     integer, parameter :: default_scheme_dirac22_or_earlier = 6, default_scheme_dirac23_or_later = 4
-    logical         :: doivo = .false., docasci = .false., docaspt2 = .false.
+    logical         :: doivo = .false., docasci = .false., docaspt2 = .false., docountndet = .false.
 
     !! =================================================
     !! Variables of CI

--- a/src/read_input_module.f90
+++ b/src/read_input_module.f90
@@ -215,6 +215,9 @@ contains
         case (".subprograms")
             call read_subprograms(unit_num)
 
+        case (".countndet")
+            docountndet = .true.
+
         case (".end")
             is_end = .true.
 

--- a/src/search_cas_configuration.f90
+++ b/src/search_cas_configuration.f90
@@ -53,18 +53,14 @@ SUBROUTINE search_cas_configuration
         current_det = find_next_configuration()
     End do
 
-    ! Stop the program if ndet == 0 because ndet == 0 means the number of CASCI configuration.
-    if (ndet == 0) then
+    if (docountndet) then
         if (rank == 0) then
-            print *, "[ERROR]: The number of CASCI configuration is 0. Therefore, subsequent calculations", &
-                " cannot be performed successfully and the program is terminated."
-            print '(a,i0,a)', " Please check your totsym parameter in your input file. your totsym parameter: ", totsym, "."
-            print *, "Following are the number of configurations for each totsym."
+            print *, 'Numbers of CASCI configurations for each total symmetry'
             do idx = 1, 2*nsymrpa
-                if (rank == 0) print '(2(a,i0))', "det_cnt( ", idx, " ) = ", det_cnt(idx)
+                print '(2(a,i0))', "ndet( ", idx, " ) = ", det_cnt(idx)
             end do
         end if
-        call stop_with_errorcode(1)
+        return ! skip the rest of validation
     end if
 
     if (rank == 0) then
@@ -160,6 +156,22 @@ contains
 
     subroutine validate_ndet_and_input_parameters()
         implicit none
+
+        ! Stop the program if ndet == 0 because the number of CASCI configuration is 0.
+        ! It means that subsequent calculations cannot be performed successfully.
+        if (ndet == 0) then
+            if (rank == 0) then
+                print *, "[ERROR]: The number of CASCI configuration is 0. Therefore, subsequent calculations", &
+                    " cannot be performed successfully and the program is terminated."
+                print '(a,i0,a)', " Please check your totsym parameter in your input file. your totsym parameter: ", totsym, "."
+                print *, "Following are the number of configurations for each totsym."
+                do idx = 1, 2*nsymrpa
+                    print '(2(a,i0))', "ndet( ", idx, " ) = ", det_cnt(idx)
+                end do
+            end if
+            call stop_with_errorcode(1)
+        end if
+
         if (ndet < selectroot) then
             if (rank == 0) then
                 print *, "ERROR: ndet < selectroot"


### PR DESCRIPTION
## このプルリクは何?
> プルリクの内容を記述してください

- 各totsymごとにCASCI配置がいくつあるかを調べるためのオプション.countndetを追加
  - このオプションを指定すると、他にどのようなオプションが指定されていても各totsymのCASCI配置を出力したあとプログラムは終了します

## 実装の内容
> 実装の内容を記述してください

## (optional) 考慮事項
> 起こりうるバグなどがわかっている場合記述してください
