### PR TITLE
Multiple cidata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         with:
           path: |
             /opt/intel/oneapi
-          key: ${{ runner.os }}-install-intel-${{ env.KEYVERSION }}
+          key: ${{ runner.os }}-install-${{ matrix.toolchain.fc }}-${{ matrix.toolchain.pkgname }}-${{ env.KEYVERSION }}
       - name: Update packages
         run: |
           sudo apt-get update

--- a/src/casci.f90
+++ b/src/casci.f90
@@ -137,6 +137,9 @@ SUBROUTINE casci
         key = 'nroot'
         write (unit_cidata) key
         write (unit_cidata) nroot
+        key = 'totsym'
+        write (unit_cidata) key
+        write (unit_cidata) totsym
         key = 'ecas'
         write (unit_cidata) key
         write (unit_cidata) ecas(1:nroot)

--- a/src/casci.f90
+++ b/src/casci.f90
@@ -22,7 +22,7 @@ SUBROUTINE casci
     real(8), allocatable    :: mat_real(:, :) ! For realonly
     real(8), allocatable    :: ecas(:)
     character(:), allocatable  :: filename
-    character(len=len_convert_int_to_chr) :: chr_root
+    character(len=len_convert_int_to_chr) :: chr_root, chr_totsym
     character(len=cidata_key_size) :: key
     integer :: dict_cas_idx_size, idx
     integer(kind=int64), allocatable :: keys(:), vals(:)
@@ -116,7 +116,8 @@ SUBROUTINE casci
     end if
     ! write CI matrix to the CIDATA file
     if (rank == 0) then ! Only master ranks are allowed to create files used by CASPT2 except for MDCINTNEW.
-        filename = 'CIDATA'
+        write (chr_totsym, *) totsym
+        filename = 'CIDATA_sym'//trim(adjustl(chr_totsym)) ! (e.g.) CIDATA_sym33
         call open_unformatted_file(unit=unit_cidata, file=filename, status='replace')
         key = "ninact"
         write (unit_cidata) key

--- a/src/read_cidata.f90
+++ b/src/read_cidata.f90
@@ -9,6 +9,8 @@ subroutine read_cidata
     use module_global_variables
     implicit none
     character(len=cidata_key_size) :: key
+    character(len=len_convert_int_to_chr) :: chr_totsym
+    character(:), allocatable :: filename
     integer :: unit, i, dict_cas_idx_size
     integer :: ninact_read, nact_read, nsec_read, nelec_read, nroot_read
     integer(kind=int64), allocatable :: dict_cas_idx_values(:)
@@ -26,7 +28,9 @@ subroutine read_cidata
     call add_essential_input("ci_coefficients")
     call add_essential_input("end")
 
-    call open_unformatted_file(unit, file="CIDATA", status="old", optional_position="append")
+    write (chr_totsym, *) totsym
+    filename = "CIDATA_sym"//trim(adjustl(chr_totsym))
+    call open_unformatted_file(unit, file=filename, status="old", optional_position="append")
     backspace (unit)
     read (unit) key
     if (trim(adjustl(key)) /= "end") then ! cidata must be ended with "end"

--- a/src/read_cidata.f90
+++ b/src/read_cidata.f90
@@ -12,7 +12,7 @@ subroutine read_cidata
     character(len=len_convert_int_to_chr) :: chr_totsym
     character(:), allocatable :: filename
     integer :: unit, i, dict_cas_idx_size
-    integer :: ninact_read, nact_read, nsec_read, nelec_read, nroot_read
+    integer :: ninact_read, nact_read, nsec_read, nelec_read, nroot_read, totsym_read
     integer(kind=int64), allocatable :: dict_cas_idx_values(:)
     real(8), allocatable    :: ecas(:)
 
@@ -23,6 +23,7 @@ subroutine read_cidata
     call add_essential_input("nelec")
     call add_essential_input("ndet")
     call add_essential_input("nroot")
+    call add_essential_input("totsym")
     call add_essential_input("ecas")
     call add_essential_input("dict_cas_idx_values")
     call add_essential_input("ci_coefficients")
@@ -81,6 +82,14 @@ subroutine read_cidata
             read (unit) nroot_read
             if (nroot_read < 0) then
                 if (rank == 0) print *, "Error: Invalid nroot in cidata file. nroot = ", nroot_read
+                call stop_with_errorcode(1)
+            end if
+            call update_esesential_input(trim(adjustl(key)), .true.)
+        case ("totsym")
+            read (unit) totsym_read
+            if (totsym_read /= totsym) then
+                if (rank == 0) print *, "Error: Invalid totsym in cidata file. totsym in cidata = ", totsym_read, &
+                    " totsym = ", totsym
                 call stop_with_errorcode(1)
             end if
             call update_esesential_input(trim(adjustl(key)), .true.)


### PR DESCRIPTION
## このプルリクは何?
> プルリクの内容を記述してください

- CIDATAのファイル名を複数のtotsymの計算に対応させるため CIDATA_sys数値 に変更
- #184 の変更によりmpiifortとmpiifx用のキャッシュを共有している状態だとmpiifort側でエラーが出るためキャッシュのkeyを別にした

## 実装の内容
> 実装の内容を記述してください

## (optional) 考慮事項
> 起こりうるバグなどがわかっている場合記述してください
