### PR TITLE
ci.yml: use ubuntu 24.04, apt-pinning for gfortran 7 and 8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,12 +107,12 @@ jobs:
     strategy:
       matrix:
         toolchain:
-          - { compiler: gcc, version: 7, image: ubuntu-20.04 }
-          - { compiler: gcc, version: 8, image: ubuntu-20.04 }
-          - { compiler: gcc, version: 9, image: ubuntu-22.04 }
-          - { compiler: gcc, version: 10, image: ubuntu-22.04 }
-          - { compiler: gcc, version: 11, image: ubuntu-22.04 }
-          - { compiler: gcc, version: 12, image: ubuntu-22.04 }
+          - { compiler: gcc, version: 7, image: ubuntu-24.04 }
+          - { compiler: gcc, version: 8, image: ubuntu-24.04 }
+          - { compiler: gcc, version: 9, image: ubuntu-24.04 }
+          - { compiler: gcc, version: 10, image: ubuntu-24.04 }
+          - { compiler: gcc, version: 11, image: ubuntu-24.04 }
+          - { compiler: gcc, version: 12, image: ubuntu-24.04 }
     runs-on: ${{ matrix.toolchain.image }}
     env:
       KEYVERSION: v1 # If you don't want to cache (intel fortran), you should change KEYVERSION.
@@ -152,6 +152,11 @@ jobs:
         run: |
           source /opt/intel/oneapi/setvars.sh
           printenv >> $GITHUB_ENV
+      - name: Add apt repository for gfortran <= 8
+        if: ${{ matrix.toolchain.version <= 8 }}
+        run: |
+          sudo add-apt-repository -y "deb http://archive.ubuntu.com/ubuntu focal main universe"
+          sudo apt-get update
       - uses: fortran-lang/setup-fortran@8821f57b53846d35d62632eb51c60ac6c4bff4ce # v1.6.1
         id: setup-fortran
         with:


### PR DESCRIPTION
## このプルリクは何?
> プルリクの内容を記述してください

- CIに使用する標準のUbuntuのバージョンを24.04に更新
- Ubuntu 24.04はgfortran 7と8をサポートしていないため以下のapt-pinningを用いて古いgfortranをインストールして使用
https://github.com/RQC-HU/dirac_caspt2/blob/51655621b54f7ca7c193e9f3677d5b6969f206a7/.github/workflows/ci.yml#L155-L159
## 実装の内容
> 実装の内容を記述してください

## (optional) 考慮事項
> 起こりうるバグなどがわかっている場合記述してください
