### PR TITLE
gfortran openmp test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,7 +181,7 @@ jobs:
       - name: Run unittest(run slowonly tests, pull_request)
         if: ${{ github.event_name == 'pull_request' }}
         run: |
-          pytest --slowonly
+          pytest ${{ steps.setenv.outputs.OPENMP_TEST_OPTION }} --slowonly
       - name: Run unittest(run normal and slow tests, push to other than main branch)
         if: ${{ github.ref_name != 'main' && github.event_name == 'push' }}
         run: |
@@ -189,4 +189,4 @@ jobs:
       - name: Run unittest(run all tests, push to main branch)
         if: ${{ github.ref_name == 'main' && github.event_name == 'push' }}
         run: |
-          pytest --all
+          pytest ${{ steps.setenv.outputs.OPENMP_TEST_OPTION }} --all

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,6 +175,9 @@ jobs:
       - name: Build source code
         run: |
           ./setup --fc ${{ steps.setenv.outputs.FC }} ${{ steps.setenv.outputs.BUILD_OPTION }} -j --build
+      - name: Set MKL_NUM_THREADS env variable to 1
+        run: |
+          echo "MKL_NUM_THREADS=1" >> $GITHUB_ENV
       - name: Run unittest(run slowonly tests, pull_request)
         if: ${{ github.event_name == 'pull_request' }}
         run: |


### PR DESCRIPTION
## このプルリクは何?
> プルリクの内容を記述してください

- #121 の問題を回避しました
  - ubuntu:24.04とdebian:bullseye-slim以外全く同じイメージでテストしたところubuntuだけこの問題が起こったので、ubuntu特有の問題と考えて根本的解決ではなく以下の回避策を行うことでissueを解決しました
  - MKL_NUM_THREADS 環境変数に1を設定して、MKL関連のルーチンは非並列で実行するように変更
  - それ以外のOpenMPで並列化している部分は並列で実行されるので、OpenMP並列のテストとしては機能しています

## 実装の内容
> 実装の内容を記述してください

## (optional) 考慮事項
> 起こりうるバグなどがわかっている場合記述してください
