### PR TITLE
add module_validation.F90 and add validate_ndet subroutine

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library(dcaspt2_module STATIC
   module_realonly.F90
   module_restart_file.F90
   module_sort_swap.F90
+  module_validation.F90
   ras_det_check.F90
   read_input_module.F90
   takekr.F90

--- a/src/dcaspt2_run_subprograms.F90
+++ b/src/dcaspt2_run_subprograms.F90
@@ -3,6 +3,7 @@ subroutine dcaspt2_run_subprograms
     use module_file_manager, only: open_formatted_file
     use module_global_variables
     use module_realonly, only: check_realonly
+    use module_validation, only: validate_ndet
     use read_input_module, only: read_input
     implicit none
     integer :: unit_input, i
@@ -43,6 +44,14 @@ subroutine dcaspt2_run_subprograms
         sumc2 = 0
         sumc2_subspace = 0
         if (enable_restart) call read_and_validate_restart_file
+
+        if (rank == 0) then
+            print '(a)', 'start casci/caspt2, rasci/raspt2 calculation'
+            print '(a,x,i0)', "totsym:", totsym
+            print '(a,x,i0)', "selectroot:", selectroot
+            print '(a,x,i0)', "nroot:", nroot
+        end if
+        if (casci_done(totsym)) call validate_ndet
 
         if (docasci .and. .not. casci_done(totsym)) then
             call r4dcasci

--- a/src/module_validation.F90
+++ b/src/module_validation.F90
@@ -1,0 +1,35 @@
+module module_validation
+
+    use module_global_variables, only: ndet, rank, nsymrpa, selectroot, nroot
+    use module_error, only: stop_with_errorcode
+    implicit none
+    private
+    public validate_ndet
+
+contains
+    subroutine validate_ndet()
+        implicit none
+        if (ndet < selectroot) then
+            if (rank == 0) then
+                print '(2(a,x,i0,x))', "ERROR: ndet < selectroot :", ndet, "<", selectroot
+                print '(a,i0,a)', "Cannot calculate ", selectroot, "th RASCI/CASCI energy"
+                print '(a,i0,a,i0)', "because the number of CASCI configuration is ", ndet, " and it is less than ", selectroot
+                print *, "Please increase the number of active orbitals or the number of electrons"
+                print *, "or decrease the number of selected root."
+                print *, "Exit the program."
+            end if
+            call stop_with_errorcode(1)
+        end if
+
+        if (ndet < nroot) then
+            if (rank == 0) then
+                print '(2(a,x,i0,x))', "WARNING: ndet < nroot:", ndet, "<", nroot
+                print '(a,i0,a)', "Cannot print ", nroot, "th RASCI/CASCI energy"
+                print '(a,i0,a,i0)', "because the number of CASCI configuration is ", ndet, " and it is less than ", nroot
+                print *, "Therefore, replace nroot with the number of CASCI configuration."
+                print *, "new nroot = ", ndet
+            end if
+            nroot = ndet
+        end if
+    end subroutine validate_ndet
+end module module_validation

--- a/src/search_cas_configuration.F90
+++ b/src/search_cas_configuration.F90
@@ -9,6 +9,7 @@ SUBROUTINE search_cas_configuration
 
     use, intrinsic :: iso_fortran_env, only: int64
     use module_global_variables
+    use module_validation, only: validate_ndet
     use module_error, only: stop_with_errorcode
     use module_dict, only: add, destruct_dict
     Implicit NONE
@@ -72,7 +73,8 @@ SUBROUTINE search_cas_configuration
         print *, 'Number of CASCI configuration = ', ndet
     end if
 
-    call validate_ndet_and_input_parameters()
+    call check_det_cnt
+    call validate_ndet
 contains
 
     function find_next_configuration() result(next_configuration)
@@ -157,7 +159,7 @@ contains
         end if
     end function is_cas_configuration
 
-    subroutine validate_ndet_and_input_parameters()
+    subroutine check_det_cnt()
         implicit none
 
         ! Stop the program if ndet == 0 because the number of CASCI configuration is 0.
@@ -174,29 +176,6 @@ contains
             end if
             call stop_with_errorcode(1)
         end if
-
-        if (ndet < selectroot) then
-            if (rank == 0) then
-                print *, "ERROR: ndet < selectroot"
-                print '(A,I0,A)', "Cannot calculate ", selectroot, "th RASCI/CASCI energy"
-                print '(A,I0,A,I0)', "because the number of CASCI configuration is ", ndet, " and it is less than ", selectroot
-                print *, "Please increase the number of active orbitals or the number of electrons"
-                print *, "or decrease the number of selected root."
-                print *, "Exit the program."
-            end if
-            call stop_with_errorcode(1)
-        end if
-
-        if (ndet < nroot) then
-            if (rank == 0) then
-                print *, "WARNING: ndet < nroot"
-                print '(A,I0,A)', "Cannot print ", nroot, "th RASCI/CASCI energy"
-                print '(A,I0,A,I0)', "because the number of CASCI configuration is ", ndet, " and it is less than ", nroot
-                print *, "Therefore, replace nroot with the number of CASCI configuration."
-                print *, "new nroot = ", ndet
-            end if
-            nroot = ndet
-        end if
-    end subroutine validate_ndet_and_input_parameters
+    end subroutine check_det_cnt
 
 end subroutine search_cas_configuration


### PR DESCRIPTION
## このプルリクは何?
> プルリクの内容を記述してください

- あるtotsymのCASPT2計算が2回目以降のときndetを超える数値のselectrootを.caspt2_cirootsで指定すると、ndetとselectrootのバリデーションチェックがないためセグフォになったり変なエネルギー値が得られるバグを修正
- 以下のようなエラーが出るようにした
  ```
  start casci/caspt2, rasci/raspt2 calculation
  totsym: 33
  selectroot: 100
  nroot: 100
  ERROR: ndet < selectroot : 6 < 100
  Cannot calculate 100th RASCI/CASCI energy
  because the number of CASCI configuration is 6 and it is less than 100
   Please increase the number of active orbitals or the number of electrons
   or decrease the number of selected root.
   Exit the program.
   ```
   
## 実装の内容
> 実装の内容を記述してください

## (optional) 考慮事項
> 起こりうるバグなどがわかっている場合記述してください
