### PR TITLE
caspt2: read_mrconne.F90: allow 0-sized ras1 or ras2 or ras3

### DIFF
--- a/src/read_mrconee.F90
+++ b/src/read_mrconee.F90
@@ -610,6 +610,7 @@ contains
         real(8), allocatable :: mo_energy_order(:)
         integer :: idx_energy_order, idx_ras_order, idx
         integer :: ras1_idx, ras2_idx, ras3_idx
+        logical :: filled
         if (rank == 0) print *, 'sizeofras', ras1_size, ras2_size, ras3_size
         if (ras1_size == 0 .and. ras2_size == 0 .and. ras3_size == 0) return ! Do nothing because ras is not configured
 ! Initialization
@@ -619,15 +620,29 @@ contains
         mo_energy_order = want_to_sort ! Save the original orbital energy order
 ! Fill ninact
         do while (idx_ras_order <= ninact)
-            if (ras1_size /= 0 .and. ras1_list(ras1_idx) == idx_energy_order) then
-                if (ras1_size > ras1_idx) ras1_idx = ras1_idx + 1 ! Skip ras1_list(ras1_idx)
-            elseif (ras2_size /= 0 .and. ras2_list(ras2_idx) == idx_energy_order) then
-                if (ras2_size > ras2_idx) ras2_idx = ras2_idx + 1 ! Skip ras2_list(ras2_idx)
-            elseif (ras3_size /= 0 .and. ras3_list(ras3_idx) == idx_energy_order) then
-                if (ras3_size > ras3_idx) ras3_idx = ras3_idx + 1 ! Skip ras3_list(ras3_idx)
-            else
+            filled = .false.
+            if (.not. filled .and. ras1_size > 0 .and. ras1_size >= ras1_idx) then
+                if (ras1_list(ras1_idx) == idx_energy_order) then
+                    ras1_idx = ras1_idx + 1 ! Skip ras1_list(ras1_idx)
+                    filled = .true.
+                end if
+            end if
+            if (.not. filled .and. ras2_size > 0 .and. ras2_size >= ras2_idx) then
+                if (ras2_list(ras2_idx) == idx_energy_order) then
+                    ras2_idx = ras2_idx + 1 ! Skip ras2_list(ras2_idx)
+                    filled = .true.
+                end if
+            end if
+            if (.not. filled .and. ras3_size > 0 .and. ras3_size >= ras3_idx) then
+                if (ras3_list(ras3_idx) == idx_energy_order) then
+                    ras3_idx = ras3_idx + 1 ! Skip ras3_list(ras3_idx)
+                    filled = .true.
+                end if
+            end if
+            if (.not. filled) then
                 want_to_sort(idx_ras_order) = mo_energy_order(idx_energy_order)
                 idx_ras_order = idx_ras_order + 1
+                filled = .true.
             end if
             idx_energy_order = idx_energy_order + 1 ! Next spinor (energy order)
         end do
@@ -671,15 +686,29 @@ contains
         end if
 ! Fill secondary
         do while (idx_ras_order <= global_sec_end)
-            if (ras1_size > 0 .and. ras1_list(ras1_idx) == idx_energy_order) then
-                if (ras1_size > ras1_idx) ras1_idx = ras1_idx + 1 ! Skip ras1_list(ras1_idx)
-            elseif (ras2_size > 0 .and. ras2_list(ras2_idx) == idx_energy_order) then
-                if (ras2_size > ras2_idx) ras2_idx = ras2_idx + 1 ! Skip ras2_list(ras2_idx)
-            elseif (ras3_size > 0 .and. ras3_list(ras3_idx) == idx_energy_order) then
-                if (ras3_size > ras3_idx) ras3_idx = ras3_idx + 1 ! Skip ras3_list(ras3_idx)
-            else
+            filled = .false.
+            if (.not. filled .and. ras1_size > 0 .and. ras1_size >= ras1_idx) then
+                if (ras1_list(ras1_idx) == idx_energy_order) then
+                    ras1_idx = ras1_idx + 1 ! Skip ras1_list(ras1_idx)
+                    filled = .true.
+                end if
+            end if
+            if (.not. filled .and. ras2_size > 0 .and. ras2_size >= ras2_idx) then
+                if (ras2_list(ras2_idx) == idx_energy_order) then
+                    ras2_idx = ras2_idx + 1 ! Skip ras2_list(ras2_idx)
+                    filled = .true.
+                end if
+            end if
+            if (.not. filled .and. ras3_size > 0 .and. ras3_size >= ras3_idx) then
+                if (ras3_list(ras3_idx) == idx_energy_order) then
+                    ras3_idx = ras3_idx + 1 ! Skip ras3_list(ras3_idx)
+                    filled = .true.
+                end if
+            end if
+            if (.not. filled) then
                 want_to_sort(idx_ras_order) = mo_energy_order(idx_energy_order)
                 idx_ras_order = idx_ras_order + 1
+                filled = .true.
             end if
             idx_energy_order = idx_energy_order + 1 ! Next spinor (energy order)
         end do


### PR DESCRIPTION
## このプルリクは何?
> プルリクの内容を記述してください

- デバッグビルド時、ras1,ras2,ras3のいずれかの大きさを0にして計算すると配列の範囲外参照が起こる問題の修正

```bash
At line 623 of file /home/noda/dev/dirac_caspt2/src/caspt2/read_mrconee.F90
Fortran runtime error: Index '1' of dimension 1 of array 'ras2_list' above upper bound of 0

Error termination. Backtrace:
#0  0x7389c2823e59 in ???
#1  0x7389c2824a71 in ???
#2  0x7389c2825082 in ???
#3  0x56069d0c70e7 in sort_list_from_energy_order_to_ras_order
        at /home/noda/dev/dirac_caspt2/src/caspt2/read_mrconee.F90:623
#4  0x56069d0cea72 in create_mo_irrep_conversion_list
        at /home/noda/dev/dirac_caspt2/src/caspt2/read_mrconee.F90:506
#5  0x56069d0c88fb in read_mrconee_
        at /home/noda/dev/dirac_caspt2/src/caspt2/read_mrconee.F90:291
```

問題が起こっていたインプット例
```
.ninact
6
.nact
6
.nelec
2
.nsec
2
.caspt2_ciroots
33 1..3
34 1
35 1
36 1
37 1
49 1 2
50 1 2
51 1 2
52 1
53 1
.subprograms
CASCI
CASPT2
.ras1
1..2
2
.ras3
9..12
2
.diracver
25
.end
```

## 実装の内容
> 実装の内容を記述してください

- インデックスが範囲外かどうかを先にチェックしてから参照するようなif文に変更

## (optional) 考慮事項
> 起こりうるバグなどがわかっている場合記述してください
