### PR TITLE
add DIRAC-CASPT2 is merged into DIRAC news

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -9,9 +9,28 @@
 
 このプロジェクトに貢献(バグレポート、機能追加など)する方法については[CONTRIBUTING.md](CONTRIBUTING.md)を参照してください
 
+## DIRAC-CASPT2がDIRACの1機能として追加されました!
+
+2025年8月13日にDIRAC-CASPT2が[DIRACの1機能としてマージされました](https://gitlab.com/dirac/dirac/-/merge_requests/312)  
+これにより、IVO/CASCI/CASPT2およびIVO/RASCI/RASPT2計算がDIRACのpamスクリプトのみを使って計算可能になりました!  
+マニュアルは[ここ](https://diracprogram.org/doc/master/manual/wave_function/caspt2.html)で公開されています  
+スタンドアロン版DIRAC-CASPT2と比較したときの主なメリットは以下の通りです
+
+- DIRAC-CASPT2のソースコードを別にインストール、ビルドする必要がなくなりました
+- CASPT2/RASPT2エネルギー計算をするのにDIRACのpamスクリプトを1回実行するだけで済むようになりました
+- IVO計算をするときに.PCMOUTオプションを使ってDFPCMOを使う必要がなくなりました。代わりに同等の情報が保存されているcheckpoint.[no]h5ファイルを使って計算を行います。checkpoint.[no]h5ファイルはDIRACの計算を行うときにオプションなしに自動的に生成されます。
+
+最新のDIRACのソースコードは以下のコマンドで入手できます  
+また、次のDIRACのメジャーリリース版であるDIRAC26からDIRAC-CASPT2がリリースバージョンで使用可能になる予定です
+
+```bash
+git clone --recursive https://gitlab.com/dirac/dirac.git
+```
+
 ## 目次
 
 - [DIRAC-CASPT2: 相対論的多配置2次摂動論プログラム](#dirac-caspt2-相対論的多配置2次摂動論プログラム)
+  - [DIRAC-CASPT2がDIRACの1機能として追加されました!](#dirac-caspt2がdiracの1機能として追加されました)
   - [Contribution](#contribution)
   - [目次](#目次)
   - [ダウンロード](#ダウンロード)

--- a/README.md
+++ b/README.md
@@ -3,6 +3,24 @@
 
 - This program performs the second order multi-configuration perturbation calculation using the IVO/CASCI/CASPT2 or IVO/RASCI/RASPT2 method with 1- and 2-electron integrals obtained from the [DIRAC](http://diracprogram.org/doku.php) calculation.
 
+## DIRAC-CASPT2 has been merged as a feature of DIRAC!
+
+13 Aug 2025, DIRAC-CASPT2 has been [merged into the DIRAC source code](https://gitlab.com/dirac/dirac/-/merge_requests/312) as a feature of DIRAC.  
+That means now you can calculate IVO/CASCI/CASPT2 or IVO/RASCI/RASPT2 with only DIRAC pam script!  
+Manual for DIRAC-CASPT2 functionality in DIRAC is available at [here](https://diracprogram.org/doc/master/manual/wave_function/caspt2.html).  
+Main advantages of DIRAC integrated DIRAC-CASPT2 are the following
+
+- You don't need to install and execute DIRAC-CASPT2 separately.
+- You can calculate CASPT2/RASPT2 energy by running DIRAC pam script just once.
+- You don't need to add .PCMOUT option to the DIRAC input when you want to use IVO, since DIRAC integrated DIRAC-CASPT2 uses checkpoint.[no]h5 file instead of DFPCMO file.
+
+You can clone the latest DIRAC source code by the following command to use DIRAC-CASPT2 functionality in DIRAC.  
+It will be available in the next DIRAC release (DIRAC26).
+
+```bash
+git clone --recursive https://gitlab.com/dirac/dirac.git
+```
+
 ## Contribution
 
 If you want to contribute to this project (bug report, feature request, pull request, etc.), please read the [CONTRIBUTING.md](CONTRIBUTING.md) file before you start contributing.
@@ -11,6 +29,7 @@ If you want to contribute to this project (bug report, feature request, pull req
 
 - [DIRAC-CASPT2: A relativistic second order multi-configuration perturbation calculation program](#dirac-caspt2-a-relativistic-second-order-multi-configuration-perturbation-calculation-program)
   - [Contribution](#contribution)
+  - [DIRAC-CASPT2 has been merged as a feature of DIRAC!](#dirac-caspt2-has-been-merged-as-a-feature-of-dirac)
   - [Table of Contents](#table-of-contents)
   - [Download](#download)
   - [Prerequisites for build](#prerequisites-for-build)


### PR DESCRIPTION
## このプルリクは何?
> プルリクの内容を記述してください

- DIRAC-CASPT2がDIRACの１機能としてマージされてDIRAC内で使えるようになったことをREADMEに記載しました

## 実装の内容
> 実装の内容を記述してください

## (optional) 考慮事項
> 起こりうるバグなどがわかっている場合記述してください
