### PR TITLE
ivo: generate ivo input parameter from caspt2 input

### DIFF
--- a/src/dcaspt2_run_subprograms.F90
+++ b/src/dcaspt2_run_subprograms.F90
@@ -2,11 +2,13 @@ subroutine dcaspt2_run_subprograms
     use dcaspt2_restart_file, only: read_and_validate_restart_file
     use module_file_manager, only: open_formatted_file
     use module_global_variables
+    use module_index_utils, only: set_global_index
     use module_realonly, only: check_realonly
     use module_validation, only: validate_ndet
     use read_input_module, only: read_input
     implicit none
     integer :: unit_input, i
+    integer :: ninact_orig, nact_orig, nelec_orig, nsec_orig
     character(:), allocatable :: filename
 
     call print_head
@@ -14,6 +16,13 @@ subroutine dcaspt2_run_subprograms
     call open_formatted_file(unit=unit_input, file='active.inp', status="old", optional_action="read")
     rewind (unit_input)
     call read_input(unit_input)
+
+    if (doivo) then
+        ! need to generate input parameter for IVO from CASCI/CASPT2 input
+        ninact_orig = ninact; nact_orig = nact; nelec_orig = nelec; nsec_orig = nsec
+        ninact = 0; nact = ninact_orig + nelec_orig; nelec = nact; nsec = nsec_orig + nact_orig - nelec_orig
+        call set_global_index
+    end if
 
     ! Read MRCONEE file (orbital energies, symmetries and multiplication tables)
     if (rank == 0) then
@@ -33,6 +42,7 @@ subroutine dcaspt2_run_subprograms
     if (doivo) then
         call r4divo_co
         call dcaspt2_deallocate
+        ninact = ninact_orig; nact = nact_orig; nelec = nelec_orig; nsec = nsec_orig
         return
     end if
 

--- a/test/dev/ivo_c2_h2o_dev/active.ivo.inp
+++ b/test/dev/ivo_c2_h2o_dev/active.ivo.inp
@@ -1,11 +1,11 @@
 .ninact
-0
+8
 .nact
-10
+4
 .nsec
-28
+26
 .nelec
-10
+2
 .caspt2_ciroots
 33 1
 .eshift

--- a/test/dev/ivo_c32h_ar_with_kappa_dev/active.ivo.inp
+++ b/test/dev/ivo_c32h_ar_with_kappa_dev/active.ivo.inp
@@ -1,11 +1,11 @@
 .ninact
-0
+12
 .nact
-14
+4
 .nelec
-14
+2
 .nsec
-24
+22
 .noccg
 3
 .noccu

--- a/test/dev/ivo_c32h_n2_dev_dirac19/active.ivo.inp
+++ b/test/dev/ivo_c32h_n2_dev_dirac19/active.ivo.inp
@@ -1,11 +1,11 @@
 .ninact
-0
+12
 .nact
-14
+4
 .nsec
-46
+44
 .nelec
-14
+2
 .caspt2_ciroots
 33 1
 .eshift

--- a/test/dev/ivo_c32h_n2_dev_dirac22/active.ivo.inp
+++ b/test/dev/ivo_c32h_n2_dev_dirac22/active.ivo.inp
@@ -1,11 +1,11 @@
 .ninact
-0
+12
 .nact
-14
+4
 .nsec
-46
+44
 .nelec
-14
+2
 .caspt2_ciroots
 33 1
 .eshift


### PR DESCRIPTION
## このプルリクは何?
> プルリクの内容を記述してください

- #212 の実装です
  - これまでのIVOのインプットも問題なく使えます

## 実装の内容
> 実装の内容を記述してください

- CASPT2のインプットにnocc[g,u]を設定すればIVO計算ができるようにするために、CASPT2のninact,nact,nelec,nsecからIVO用のninact,nact,nelec,nsecを計算して、IVOではそのパラメータを使うように変更しました

## (optional) 考慮事項
> 起こりうるバグなどがわかっている場合記述してください